### PR TITLE
Stop forcing INFO log level for weld

### DIFF
--- a/src/main/java/com/itemis/maven/plugins/cdi/AbstractCDIMojo.java
+++ b/src/main/java/com/itemis/maven/plugins/cdi/AbstractCDIMojo.java
@@ -182,11 +182,9 @@ public class AbstractCDIMojo extends AbstractMojo implements Extension {
     }
 
     System.setProperty("org.jboss.logging.provider", "slf4j");
-    String logLevel = "info";
     if (getLog().isDebugEnabled()) {
-      logLevel = "debug";
+      System.setProperty("org.slf4j.simpleLogger.log.org.jboss.weld", "debug");
     }
-    System.setProperty("org.slf4j.simpleLogger.log.org.jboss.weld", logLevel);
 
     Weld weld = new Weld();
     weld.addExtension(this);


### PR DESCRIPTION
In my mojo, I want to switch Weld logging to WARNING, but could not do that because AbstractCDIMojo always sets the level back to INFO.

However, the [maven defaut logging configuration](https://github.com/apache/maven/blob/master/apache-maven/src/conf/logging/simplelogger.properties) already sets the global default level to INFO, so that particular `setProperty()` call is effectively a no-op anyway.

If AbstractCDIMojo only sets the Weld log level if debug logging is enabled, mojo authors and end-users alike can freely change the Weld log level again.